### PR TITLE
fixed #110. Dont show the social buttons anymore.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,9 +51,7 @@
   </section>
 
   <%= render 'layouts/footer' %>
-  <aside class = "visible-desktop">
-    <%= render 'shared/social_buttons' %>
-  </aside>
+  <%= render 'feedback/dialog_feedback' %>
   <%= debug(params) if Rails.env.development? %>
 
 </body>


### PR DESCRIPTION
Don't show the social buttons anymore because they take away the focus from the important stuff. 
