### PR TITLE
expose NPM dist tags on the product page;

### DIFF
--- a/app/views/products/_product_show_other_versions.html.erb
+++ b/app/views/products/_product_show_other_versions.html.erb
@@ -5,18 +5,37 @@
       <%= pluralize(@product.versions.count, 'Versions') %>
     </h3>
   </div>
+
+  <!-- version list -->
   <div class="box content scrollable-box" style = "min-height: 1em; max-height: 14em;" >
     <% versions = @product.sorted_versions %>
-    <% versions = [] if versions.nil? %>
-    <% versions[0..100].each do |version|  %>
+    <% versions.to_a.take(100).each do |version|  %>
 
       <div>
         <% if VersionTagRecognizer.release?(version.to_s) %>
-          <a href="<%=product_version_path( @product, version.to_param )%>"><%=version.to_s%></a>
+          <a href="<%=product_version_path( @product, version.to_param )%>">
+            <%=version.to_s%>
+          </a>
         <% else %>
-          <a style="color: brown" href="<%=product_version_path( @product, version.to_param )%>"><%=version.to_s%></a>
+          <a style="color: brown" href="<%=product_version_path( @product, version.to_param )%>">
+            <%=version.to_s%>
+          </a>
         <% end %>
-        <span class="meta_text_small">(<%= version.released_or_detected.in_time_zone(timezone).strftime("%b %d, %Y") %>)</span>
+
+        <!-- Distribution tags aka version aliases for NPM packages -->
+        <% if version.tags.to_a.size %>
+          <span class="meta_text_small">
+            &ndash; <%= version.tags.to_a.take(3).join(',') %>
+            <% if version.tags.to_a.size > 3 %>
+              &hellip;
+            <% end %>
+          </span>
+        <% end %>
+
+        <!-- Release date -->
+        <span class="meta_text_small">
+          (<%= version.released_or_detected.in_time_zone(timezone).strftime("%b %d, %Y") %>)
+        </span>
 
         <% if svs && !svs.empty? %>
           <% svs.each do |sv| %>

--- a/app/views/products/helpers/_kpis.html.erb
+++ b/app/views/products/helpers/_kpis.html.erb
@@ -4,7 +4,9 @@
   <div class="kpibox flash info l_margin_bottom_5" >
     <b>Current:</b>
     <% if @product.version_newest && !@product.version_newest.to_s.eql?(@product.version.to_s) %>
-      <a href="/<%= @product.language_esc %>/<%= @product.to_param %>/<%= @product.version_newest.to_s %>" ><%= @product.version_newest.to_s %></a>
+      <a href="/<%= @product.language_esc %>/<%= @product.to_param %>/<%= @product.version_newest.to_s %>" >
+        <%= @product.version_newest.to_s %>
+      </a>
     <% else %>
       <%= @product.version_newest.to_s %>
     <% end %>


### PR DESCRIPTION
Hi,

this PR will solve the issue #698 and exposes `dist_tags` attached to NPM packages like shown on screenshot:

![screen shot 2017-09-08 at 15 18 57](https://user-images.githubusercontent.com/1223889/30213692-233c5c80-94aa-11e7-85cd-2708091cef32.png)
